### PR TITLE
Converting TTF/OTF to web fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 .awscredentials
 /test
+config.ext.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@ WORKDIR /app
 
 RUN apt-get -y update 
 
+RUN apt-get install -y \
+	python3 \
+	python3-pip \
+	python3-setuptools \
+	groff \
+	less \
+	&& pip3 install --upgrade pip \
+	&& apt-get clean && \
+	pip3 install awscli
+
 RUN apt-get -y install imagemagick
 RUN apt-get -y install jpegoptim 
 RUN apt-get -y install pngquant 
@@ -16,16 +26,13 @@ RUN sed -i "s/jessie main/jessie main contrib non-free/" /etc/apt/sources.list &
 
 RUN npm i -g svgo
 
-RUN apt-get update && \
-	apt-get install -y \
-	python3 \
-	python3-pip \
-	python3-setuptools \
-	groff \
-	less \
-	&& pip3 install --upgrade pip \
-	&& apt-get clean && \
-	pip3 install awscli
+RUN apt-get -y install fontforge
+
+RUN apt-get -y install && \
+	git clone --recursive https://github.com/google/woff2.git /usr/share/woff2 && \
+	cd /usr/share/woff2 && \
+	make clean all && \
+	ln -svf /usr/share/woff2/woff2_compress /usr/bin/woff2_compress
 
 COPY package.json /app
 RUN npm i

--- a/README.md
+++ b/README.md
@@ -56,10 +56,17 @@ Example:
 | processor.svg              | bool     | SVGs          | On/Off `svgo` optimizer                              | true              |
 | processor.lazyLoadBlurried | bool     | images        | On/Off generation of a blurry image                  | true              |
 | processor.videoThumbs      | bool     | videos        | On/Off generation of thumbnails extracted from video | true              |
+| processor.fontCSS          | bool     | fonts         | On/Off generation of font-face declar via CSS/HTML   | true              |
 | converter.mp4              | bool     | videos        | On/Off conversion to MP4                             | true              |
 | converter.webm             | bool     | videos        | On/Off conversion to WEBM                            | true              |
 | converter.webp             | bool     | images        | On/Off conversion to WEBP                            | true              |
 | converter.mp3              | bool     | audios        | On/Off conversion to MP3                             | true              |
+| converter.ttf              | bool     | fonts         | On/Off conversion to TTF                             | true              |
+| converter.otf              | bool     | fonts         | On/Off conversion to OTF                             | true              |
+| converter.eot              | bool     | fonts         | On/Off conversion to EOT                             | true              |
+| converter.svg              | bool     | fonts         | On/Off conversion to SVG                             | true              |
+| converter.woff             | bool     | fonts         | On/Off conversion to WOFF                            | true              |
+| converter.woff2            | bool     | fonts         | On/Off conversion to WOFF2                           | true              |
 
 ### `resize`
 

--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ Example:
 | processor.svg              | bool     | SVGs          | On/Off `svgo` optimizer                              | true              |
 | processor.lazyLoadBlurried | bool     | images        | On/Off generation of a blurry image                  | true              |
 | processor.videoThumbs      | bool     | videos        | On/Off generation of thumbnails extracted from video | true              |
-| processor.fontCSS          | bool     | fonts         | On/Off generation of font-face declar via CSS/HTML   | true              |
+| processor.fontCSS          | bool     | TTFs/OTFs     | On/Off generation of font-face declar via CSS/HTML   | true              |
 | converter.mp4              | bool     | videos        | On/Off conversion to MP4                             | true              |
 | converter.webm             | bool     | videos        | On/Off conversion to WEBM                            | true              |
 | converter.webp             | bool     | images        | On/Off conversion to WEBP                            | true              |
 | converter.mp3              | bool     | audios        | On/Off conversion to MP3                             | true              |
-| converter.ttf              | bool     | fonts         | On/Off conversion to TTF                             | true              |
-| converter.otf              | bool     | fonts         | On/Off conversion to OTF                             | true              |
-| converter.eot              | bool     | fonts         | On/Off conversion to EOT                             | true              |
-| converter.svg              | bool     | fonts         | On/Off conversion to SVG                             | true              |
-| converter.woff             | bool     | fonts         | On/Off conversion to WOFF                            | true              |
-| converter.woff2            | bool     | fonts         | On/Off conversion to WOFF2                           | true              |
+| converter.ttf              | bool     | TTFs/OTFs     | On/Off conversion to TTF                             | true              |
+| converter.otf              | bool     | TTFs/OTFs     | On/Off conversion to OTF                             | true              |
+| converter.eot              | bool     | TTFs/OTFs     | On/Off conversion to EOT                             | true              |
+| converter.svg              | bool     | TTFs/OTFs     | On/Off conversion to SVG                             | true              |
+| converter.woff             | bool     | TTFs/OTFs     | On/Off conversion to WOFF                            | true              |
+| converter.woff2            | bool     | TTFs/OTFs     | On/Off conversion to WOFF2                           | true              |
 
 ### `resize`
 

--- a/config.json
+++ b/config.json
@@ -12,13 +12,20 @@
 		"gif": true,
 		"svg": true,
 		"lazyLoadBlurried": true,
-		"videoThumbs": true
+		"videoThumbs": true,
+		"fontCSS": true
 	},
 	"converter": {
 		"mp4": true,
 		"webm": true,
 		"webp": true,
-		"mp3": true
+		"mp3": true,
+		"ttf": true,
+		"otf": true,
+		"svg": true,
+		"eot": true,
+		"woff": true,
+		"woff2": true
 	},
 	"resize": {
 		"dimensions": [200, 400, 800, 1200],

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -68,7 +68,60 @@ async function convertToMP3(tommy, filepath) {
 	return dst_path;
 }
 
+async function convertUsingFontForge(tommy, format, filepath) {
+	if (tommy.config.converter[format] == false) return false;
+
+	const dst_path = filepath.replace(/\..+$/g, '.' + format);
+	await overwriteProtection(tommy, filepath, dst_path);
+
+	console.debug(`Converting to ${format.toUpperCase()} <${filepath}>`);
+	await util.execPromise(`FONTFORGE_LANGUAGE=ff fontforge \
+		-c 'Open("${filepath}"); Generate("${dst_path}")'`);
+	return dst_path;
+}
+
+async function convertToOTF(tommy, filepath) {
+	return convertUsingFontForge(tommy, 'otf', filepath);
+}
+
+async function convertToTTF(tommy, filepath) {
+	return convertUsingFontForge(tommy, 'ttf', filepath);
+}
+
+async function convertToSVG(tommy, filepath) {
+	return convertUsingFontForge(tommy, 'svg', filepath);
+}
+
+async function convertToEOT(tommy, filepath) {
+	return convertUsingFontForge(tommy, 'eot', filepath);
+}
+
+async function convertToWOFF(tommy, filepath) {
+	return convertUsingFontForge(tommy, 'woff', filepath);
+}
+
+async function convertToWOFF2(tommy, filepath) {
+	const format = 'woff2';
+
+	if (tommy.config.converter[format] == false) return false;
+
+	const dst_path = filepath.replace(/\..+$/g, '.' + format);
+	await overwriteProtection(tommy, filepath, dst_path);
+
+	console.debug(`Converting to ${format.toUpperCase()} <${filepath}>`);
+	await util.execPromise(`woff2_compress 
+		"${filepath}" \
+		"${dst_path}"`);
+	return dst_path;
+}
+
 exports.toWEBP = convertToWEBP;
 exports.toMP4 = convertToMP4;
 exports.toWEBM = convertToWEBM;
 exports.toMP3 = convertToMP3;
+exports.toOTF = convertToOTF;
+exports.toTTF = convertToTTF;
+exports.toSVG = convertToSVG;
+exports.toEOT = convertToEOT;
+exports.toWOFF = convertToWOFF;
+exports.toWOFF2 = convertToWOFF2;

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -109,9 +109,8 @@ async function convertToWOFF2(tommy, filepath) {
 	await overwriteProtection(tommy, filepath, dst_path);
 
 	console.debug(`Converting to ${format.toUpperCase()} <${filepath}>`);
-	await util.execPromise(`woff2_compress 
-		"${filepath}" \
-		"${dst_path}"`);
+	await util.execPromise(`woff2_compress \
+		"${filepath}"`);
 	return dst_path;
 }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,5 +1,7 @@
 const sizeOf = require('image-size');
 const util = require('./util');
+const fs = require('fs');
+const path = require('path');
 
 async function processImage(tommy, filepath) {
 	if (tommy.config.processor.image == false) return false;
@@ -155,11 +157,51 @@ async function processResize(tommy, filepath) {
 	return resized_images;
 }
 
+async function processFontCSS(tommy, filepath) {
+	if (tommy.config.processor.fontCSS == false) return false;
+
+	const file_url = filepath.replace(/\..+$/, '').replace(tommy.dst, '');
+	const name = path.basename(file_url);
+
+	const css_file = path.join(path.dirname(filepath.replace(tommy.src, tommy.dst)), name + '.css');
+	const css_string = `@font-face {
+		font-family: '${name}';
+		src: url('${file_url}.eot'); /* IE9 Compat Modes */
+		src: url('${file_url}.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+			  url('${file_url}.woff2') format('woff2'), /* Super Modern Browsers */
+			  url('${file_url}.woff') format('woff'), /* Pretty Modern Browsers */
+			  url('${file_url}.ttf')  format('truetype'), /* Safari, Android, iOS */
+			  url('${file_url}.svg#${name}') format('svg'); /* Legacy iOS */
+	}`;
+
+	console.debug(`Extracting CSS font-face declaration to <${css_file}>`);
+	fs.writeFileSync(css_file, css_string);
+
+	const html_file = css_file.replace('.css', '.html');
+	const sentence = 'The quick brown fox jumps over the lazy dog';
+	const html_string = `<!doctype html>
+		<style>${css_string.replace(new RegExp(file_url, 'g'), `./${name}`)}</style>
+		<style>body { font-family: "${name}"; }</style>
+		<h1>${name}</h1>
+		<hr/>
+		<h1>${sentence}</h1>
+		<h2>${sentence}</h2>
+		<h3>${sentence}</h3>
+		<p>${sentence}</p>
+	`;
+
+	console.debug(`Extracting HTML test for font-face declaration to <${html_file}>`);
+	fs.writeFileSync(html_file, html_string);
+
+	return css_file;
+}
+
 exports.image = processImage;
 exports.poster = processPoster;
 exports.videoThumbs = processVideoThumbs;
 exports.resize = processResize;
 exports.lazyLoadBlurried = processLazyLoadBlurriedImage;
+exports.fontCSS = processFontCSS;
 
 exports.JPG = processJPG;
 exports.PNG = processPNG;

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,7 +6,7 @@ async function execPromise(command, opt = {
 	return new Promise((resolve, reject) => {
 
 		let child = exec(command, {}, (err, stdout, stderr) => {
-			if (err) return reject(stderr);
+			if (err) return reject(stderr || stdout);
 			return resolve(stdout);
 		});
 

--- a/macos.sh
+++ b/macos.sh
@@ -5,4 +5,5 @@ brew install pngquant
 brew install webp
 brew install ffmpeg
 npm -g i svgo
+brew install fontforge
 brew install aws-cli

--- a/macos.sh
+++ b/macos.sh
@@ -6,4 +6,5 @@ brew install webp
 brew install ffmpeg
 npm -g i svgo
 brew install fontforge
+brew install woff2
 brew install aws-cli

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -7,9 +7,10 @@ docker build -t $DOCKER_IMAGE . && \
 docker run -t \
 -v "$(pwd)/test/src":"/src" \
 -v "$(pwd)/test/dst":"/dst" \
--v "$(pwd)/config.json":"/root/config.json" \
+-v "$(pwd)/config.ext.json":"/root/config.ext.json" \
 -v "$(pwd)/.awscredentials":"/root/.aws/credentials" \
 kopiro/tommy \
 --src "/src" \
 --dst "/dst" \
---config "/root/config.json"
+--config "/root/config.ext.json" \
+--force

--- a/test-macos.sh
+++ b/test-macos.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 tommy \
 --src ./test/src \
---dst ./test/dst
+--dst ./test/dst \
+--config ./config.ext.json \
+--force

--- a/tommy.js
+++ b/tommy.js
@@ -171,6 +171,22 @@ class Tommy {
 					} else if (/\.(ogg|wav|aif|ac3|aac)$/i.test(filepath)) {
 						await converter.toMP3(this, filepath);
 
+					} else if (/\.(ttf)$/i.test(filepath)) {
+						await converter.toOTF(this, filepath);
+						await converter.toSVG(this, filepath);
+						await converter.toEOT(this, filepath);
+						await converter.toWOFF(this, filepath);
+						await converter.toWOFF2(this, filepath);
+						await processor.fontCSS(this, filepath);
+
+					} else if (/\.(otf)$/i.test(filepath)) {
+						await converter.toTTF(this, filepath);
+						await converter.toSVG(this, filepath);
+						await converter.toEOT(this, filepath);
+						await converter.toWOFF(this, filepath);
+						await converter.toWOFF2(this, filepath);
+						await processor.fontCSS(this, filepath);
+
 					}
 
 					console.groupEnd();
@@ -181,7 +197,7 @@ class Tommy {
 
 				} catch (err) {
 					console.groupEnd();
-					console.error(`Error in processing ${file}: ${err.message}`);
+					console.error(`Error in processing ${file}`, err);
 				}
 
 			}


### PR DESCRIPTION
Enabled conversion of fonts to:
- TTF to OTF, EOT, SVG, WOFF, WOFF2
- OTF to TTF, EOT, SVG, WOFF, WOFF2

Furthermore, a sample CSS and HTML file with the font-face declaration for testing or import purposes will be generated.

Configuration keys:

`processor.fontCSS` and `converter[ttf,eot,otf,svg,woff,woff2]`

Sample HTML page:

![image](https://user-images.githubusercontent.com/839700/46962076-79b53c00-d0a2-11e8-9557-bf6f81eaebb5.png)
