### PR TITLE
Compile FONTFORGE into container - installation via APT is corrupted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 RUN apt-get -y update 
 
+# ------- AWSCLI ---------
+
 RUN apt-get install -y \
 	python3 \
 	python3-pip \
@@ -14,25 +16,55 @@ RUN apt-get install -y \
 	&& apt-get clean && \
 	pip3 install awscli
 
-RUN apt-get -y install imagemagick
-RUN apt-get -y install jpegoptim 
-RUN apt-get -y install pngquant 
-RUN apt-get -y install gifsicle 
-RUN apt-get -y install webp
+# ------- FFMPEG ---------
 
 RUN sed -i "s/jessie main/jessie main contrib non-free/" /etc/apt/sources.list && \
 	echo "deb http://http.debian.net/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list && \
 	apt-get update && apt-get install -y ffmpeg
 
-RUN npm i -g svgo
-
-RUN apt-get -y install fontforge
+# ------- WOFF2 ---------
 
 RUN apt-get -y install && \
 	git clone --recursive https://github.com/google/woff2.git /usr/share/woff2 && \
 	cd /usr/share/woff2 && \
 	make clean all && \
 	ln -svf /usr/share/woff2/woff2_compress /usr/bin/woff2_compress
+
+# ------- PROCESSORS ---------
+
+RUN npm i -g svgo
+
+RUN apt-get -y install imagemagick jpegoptim pngquant gifsicle webp
+
+# ------- FONT FORGE ---------
+
+RUN apt-get -y install autotools-dev libjpeg-dev libtiff5-dev libpng-dev libgif-dev libxt-dev libfreetype6-dev autoconf automake libtool libltdl7-dev libxml2-dev libuninameslist-dev libspiro-dev python-dev libpango1.0-dev libcairo2-dev chrpath unifont 
+
+RUN git clone https://github.com/fontforge/libspiro.git /usr/share/libspiro && \
+	cd /usr/share/libspiro && \
+	autoreconf -i && \
+	automake --foreign -Wall && \
+	./configure && \
+	make && \
+	make install
+
+RUN git clone https://github.com/fontforge/libuninameslist.git /usr/share/libuninameslist && \
+	cd /usr/share/libuninameslist && \
+	autoreconf -i && \
+	automake --foreign && \
+	./configure && \
+	make && \
+	make install
+
+RUN git clone https://github.com/fontforge/fontforge.git /usr/share/fontforge && \
+	cd /usr/share/fontforge && \
+	./bootstrap && \
+	./configure && \
+	make && \
+	make install && \
+	ldconfig
+
+# ------- APP ---------
 
 COPY package.json /app
 RUN npm i

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -100,7 +100,7 @@ async function convertToWOFF2(tommy, filepath) {
 	const dst_path = filepath.replace(util.REGEX_EXT, '.woff');
 	await util.overwriteProtection(tommy, filepath, dst_path);
 
-	console.debug(`Converting to WOFF <${dst_path}>`);
+	console.debug(`Converting to WOFF2 <${dst_path}>`);
 	await util.execPromise(`woff2_compress \
 		"${filepath}"`);
 	return dst_path;

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -1,13 +1,15 @@
 const util = require('./util');
 
 async function syncFromRemote(tommy) {
-	return util.execPromise(`aws s3 sync "s3://${tommy.s3Bucket}" "${tommy.dst}" --exclude ".DS_Store" --delete`, {
+	if (tommy.config.s3Bucket == null) throw new Error('Invalid bucket');
+	return util.execPromise(`aws s3 sync "s3://${tommy.config.s3Bucket}" "${tommy.dst}" --exclude ".DS_Store"`, {
 		verbose: true
 	});
 }
 
 async function syncToRemote(tommy) {
-	return util.execPromise(`aws s3 sync "${tommy.dst}" "s3://${tommy.s3Bucket}" --exclude ".DS_Store" --delete`, {
+	if (tommy.config.s3Bucket == null) throw new Error('Invalid bucket');
+	return util.execPromise(`aws s3 sync "${tommy.dst}" "s3://${tommy.config.s3Bucket}" --exclude ".DS_Store" --delete`, {
 		verbose: true
 	});
 }

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -8,12 +8,13 @@ touch .config.ext.json
 docker build -t $DOCKER_IMAGE . && \
 
 docker run -t \
--v "$(pwd)/test/src":"/src" \
--v "$(pwd)/test/dst":"/dst" \
+-v "$(pwd)/.test/src":"/src" \
+-v "$(pwd)/.test/dst":"/dst" \
 -v "$(pwd)/.config.ext.json":"/root/config.ext.json" \
 -v "$(pwd)/.awscredentials":"/root/.aws/credentials" \
 kopiro/tommy \
 --src "/src" \
 --dst "/dst" \
 --config "/root/config.ext.json" \
+-e "DEBUG=1" \
 $1


### PR DESCRIPTION
Added compilation of fontforge instead of installing via `apt-get`: that installation is corrupted.

```
RUN apt-get -y install autotools-dev libjpeg-dev libtiff5-dev libpng-dev libgif-dev libxt-dev libfreetype6-dev autoconf automake libtool libltdl7-dev libxml2-dev libuninameslist-dev libspiro-dev python-dev libpango1.0-dev libcairo2-dev chrpath unifont 

RUN git clone https://github.com/fontforge/libspiro.git /usr/share/libspiro && \
	cd /usr/share/libspiro && \
	autoreconf -i && \
	automake --foreign -Wall && \
	./configure && \
	make && \
	make install

RUN git clone https://github.com/fontforge/libuninameslist.git /usr/share/libuninameslist && \
	cd /usr/share/libuninameslist && \
	autoreconf -i && \
	automake --foreign && \
	./configure && \
	make && \
	make install

RUN git clone https://github.com/fontforge/fontforge.git /usr/share/fontforge && \
	cd /usr/share/fontforge && \
	./bootstrap && \
	./configure && \
	make && \
	make install && \
	ldconfig
```